### PR TITLE
CSS / Enabling 0<>3+ payment provider

### DIFF
--- a/src/Pages/Payment/Payment.scss
+++ b/src/Pages/Payment/Payment.scss
@@ -30,13 +30,13 @@
     column-gap: 1em;
   }
   @mixin btn-pay {
-    //box-sizing: border-box;
     display: flex;
     flex-grow: 1;
     border-radius: 6px;
     justify-content: center;
     align-items: center;
     border: none;
+    box-sizing: border-box;
     &:active {
       opacity: 0.8;
     }

--- a/src/Pages/Payment/Payment.scss
+++ b/src/Pages/Payment/Payment.scss
@@ -21,11 +21,18 @@
   hr {
     background: $input-background;
   }
-
-  @mixin btn-pay {
-    width: 48%;
-    height: 40px;
+  .payment-btn-container {
     display: flex;
+    justify-content: space-between;
+    align-content: space-between;
+    align-items: stretch;
+    height: 40px;
+    column-gap: 1em;
+  }
+  @mixin btn-pay {
+    //box-sizing: border-box;
+    display: flex;
+    flex-grow: 1;
     border-radius: 6px;
     justify-content: center;
     align-items: center;
@@ -66,12 +73,6 @@
     &:hover {
       background: #c0e4f8;
     }
-  }
-  .payment-btn-container {
-    display: flex;
-    flex-wrap: wrap;
-    margin: 15px 0 15px 0;
-    justify-content: space-between;
   }
   .pay-btn {
     width: 100%;


### PR DESCRIPTION
Hello 👋 

I've just improved a bit how the payment provider buttons were displayed : 
- if only 1 : full width
- if 2 : 50/50
and so on...

For now we only have 3 of them (Paypal, Google Pay, Apple Pay), but this improvement also works if we add more in the future :) 

Cheers !